### PR TITLE
Fix Zoomify Crashing on latest Versions of mod. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,18 @@ repositories {
 		url = "https://maven.terraformersmc.com/"
 	}
 	maven {
+		name = "Fabric Language Kotlin"
+		url = "https://maven.fabricmc.net/"
+	}
+	maven {
+		name = "xanderRepo"
+		url = "https://maven.isxander.dev/releases"
+	}
+	maven {
+		name = "Quilt"
+		url = "https://maven.quiltmc.org/repository/release"
+	}
+	maven {
 		url = 'https://oss.sonatype.org/content/repositories/snapshots'
 	}
 	maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,8 @@ modernkeybinding_version=1.20.X-1.2.0
 controlling_version=6ipZLQSK
 searchables_version=eh4IBlu2
 immediatelyfast_version=1.2.18+1.20.4-fabric
-zoomify_version=2.14.0+1.20.1
+fabric_language_kotlin_version=1.10.17+kotlin.1.9.22
+zoomify_version=2.14.2+1.20.1
 resolution_control_plus_version=1.20-3.0.0
 perspective_mod_redux_version=fabric-1.17-0.0.5_01
 

--- a/src/main/java/com/tacz/guns/compat/zoomify/ZoomifyCompat.java
+++ b/src/main/java/com/tacz/guns/compat/zoomify/ZoomifyCompat.java
@@ -14,7 +14,12 @@ public class ZoomifyCompat {
 
     public static double getFov(double fov, float tickDelta) {
         if (INSTALLED) {
-            return fov / Zoomify.getZoomDivisor(tickDelta);
+            try {
+                return fov / Zoomify.getZoomDivisor(tickDelta);
+            } catch (Exception e) {
+                System.err.println("Error while getting Zoomify zoom divisor: " + e.getMessage());
+                return fov;
+            }
         }
         return fov;
     }


### PR DESCRIPTION
just makes it so the 2.14.2 version of the Zoomify mod does not cause your game to crash when a world is loaded